### PR TITLE
chore: align tooling with cross-repo standard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Format check
+        run: yarn format:check
+
       - name: Lint
         run: yarn lint
+
+      - name: Build
+        run: yarn build
 
       - name: Test
         run: yarn coverage

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ netlify
 
 # Test coverage
 coverage
+
+# TypeScript composite build artifacts
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
+vitest.config.js
+vitest.config.d.ts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint && yarn test:run
+yarn format:check && yarn lint && tsc -b && yarn test:run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,11 @@ yarn build        # Type-check (tsc) then build to dist/
 yarn build:netlify  # Build two output dirs: netlify/ and netlify/unixtime/ (for Netlify subdirectory)
 yarn preview      # Preview the production build locally
 yarn lint         # ESLint with auto-fix on src/
+yarn format       # Prettier write on src/ and index.html
+yarn format:check # Prettier check (no write) — used in hook and CI
 ```
 
-**Pre-commit hook (husky):** runs `yarn lint && yarn test:run` automatically on each commit.
+**Pre-commit hook (husky):** runs `yarn format:check && yarn lint && tsc -b && yarn test:run` automatically on each commit.
 
 **Tests:** Vitest + Testing Library. Run `yarn test` (watch), `yarn test:run` (single pass), or `yarn coverage` (coverage report).
 - Unit tests: `src/lib/functions/convertTime.test.ts`, `src/lib/functions/index.test.ts`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "lint": "eslint --fix ./src",
     "format": "prettier --write src index.html",
+    "format:check": "prettier --check src index.html",
     "test": "vitest",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",

--- a/src/components/Converter/Result.tsx
+++ b/src/components/Converter/Result.tsx
@@ -34,9 +34,7 @@ const Result = ({ data }: IResultProps) => {
 
   useEffect(() => {
     const documentTime =
-      !timezone || timezone === UTC
-        ? dateTime.utc()
-        : dateTime.tz(timezone);
+      !timezone || timezone === UTC ? dateTime.utc() : dateTime.tz(timezone);
     document.title = documentTime.format(LONG_DATE) + ' - ' + DOCUMENT_TITLE;
   }, [dateTime, timezone]);
 

--- a/src/lib/hooks/useConversion.ts
+++ b/src/lib/hooks/useConversion.ts
@@ -21,8 +21,14 @@ const useConversion = () => {
 
   useEffect(() => {
     const { time, timezone: convertTimezone } = conversion || ({} as IFormData);
-    const { dateTime, time: convertedTime, timezone, error, warning, title } =
-      convertTime(time, convertTimezone);
+    const {
+      dateTime,
+      time: convertedTime,
+      timezone,
+      error,
+      warning,
+      title,
+    } = convertTime(time, convertTimezone);
 
     setData({ dateTime, time: convertedTime, timezone, error, warning, title });
   }, [conversion]);

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "composite": true,
+    "lib": ["ESNext"],
+    "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
## Summary

- Adds `format:check` script (`prettier --check`) to `package.json`
- Updates pre-commit hook to run `format:check`, `lint`, `tsc -b`, and tests (previously only `lint` + `test:run`)
- Adds Format check and Build steps to the CI workflow
- Fixes `tsconfig.node.json`: adds `lib` and `skipLibCheck` so `tsc -b` works correctly with the composite build
- Gitignores `tsc -b` build artifacts (`.tsbuildinfo`, compiled vite/vitest config files)
- Fixes two files that were out of Prettier spec (`Result.tsx`, `useConversion.ts`)
- Updates `CLAUDE.md` to document the new scripts and hook

## Test plan

- [x] `yarn format:check` passes
- [x] `yarn lint` passes
- [x] `tsc -b` passes
- [x] `yarn test:run` — 57 tests across 9 files all pass
- [x] Pre-commit hook ran cleanly on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)