### PR TITLE
style: switch to Prettier defaults, reformat codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,1 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "tabWidth": 2
-}
+{}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ This is a single-page React + TypeScript app built with Vite 8 (`@vitejs/plugin-
 
 **ESLint + Prettier conventions to follow:**
 - Config: `eslint.config.mjs` (ESLint 9 flat config). No `.eslintrc`.
-- Formatting is handled by Prettier (`.prettierrc`): single quotes, semi-colons, tab width (i.e., 2 spaces). Run `yarn format` to apply.
+- Formatting is handled by Prettier (`.prettierrc`): Prettier defaults only, no custom formatting. Run `yarn format` to apply.
 - ESLint handles code quality only — recommended rules from `@typescript-eslint`, `eslint-plugin-react`, and `eslint-plugin-react-hooks`, plus:
   - Interfaces must be prefixed with `I` (e.g. `IFormData`).
   - `react/jsx-no-bind` is enabled — don't pass inline arrow functions as JSX props; use `useCallback`.

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 
     <script>
       (() =>
-        !window.location.pathname.endsWith('/') &&
-        window.location.replace(window.location.href + '/'))();
+        !window.location.pathname.endsWith("/") &&
+        window.location.replace(window.location.href + "/"))();
     </script>
 
     <link

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import useConversion from './lib/hooks/useConversion';
-import Header from './components/Header/Header';
-import Main from './components/Shared/Main';
-import Form from './components/Converter/Form';
-import Result from './components/Converter/Result';
+import React from "react";
+import useConversion from "./lib/hooks/useConversion";
+import Header from "./components/Header/Header";
+import Main from "./components/Shared/Main";
+import Form from "./components/Converter/Form";
+import Result from "./components/Converter/Result";
 
 function App() {
   const { data, setConversion } = useConversion();

--- a/src/components/Converter/Form.test.tsx
+++ b/src/components/Converter/Form.test.tsx
@@ -1,50 +1,50 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import Form from './Form';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Form from "./Form";
 
-describe('Form', () => {
-  it('renders the time input', () => {
+describe("Form", () => {
+  it("renders the time input", () => {
     render(<Form setConversion={vi.fn()} />);
     expect(
       screen.getByPlaceholderText(/date and time or a timestamp/i),
     ).toBeInTheDocument();
   });
 
-  it('renders the Convert button', () => {
+  it("renders the Convert button", () => {
     render(<Form setConversion={vi.fn()} />);
     expect(
-      screen.getByRole('button', { name: /convert/i }),
+      screen.getByRole("button", { name: /convert/i }),
     ).toBeInTheDocument();
   });
 
-  it('renders the timezone select', () => {
+  it("renders the timezone select", () => {
     render(<Form setConversion={vi.fn()} />);
     // react-select renders the placeholder as a <div>, not an input placeholder attr
     expect(screen.getByText(/Enter a time zone/i)).toBeInTheDocument();
   });
 
-  it('calls setConversion with the entered time value on submit', async () => {
+  it("calls setConversion with the entered time value on submit", async () => {
     const setConversion = vi.fn();
     render(<Form setConversion={setConversion} />);
 
     const input = screen.getByPlaceholderText(/date and time or a timestamp/i);
-    await userEvent.type(input, '1700000000');
-    await userEvent.click(screen.getByRole('button', { name: /convert/i }));
+    await userEvent.type(input, "1700000000");
+    await userEvent.click(screen.getByRole("button", { name: /convert/i }));
 
     expect(setConversion).toHaveBeenCalledOnce();
     expect(setConversion).toHaveBeenCalledWith(
-      expect.objectContaining({ time: '1700000000' }),
+      expect.objectContaining({ time: "1700000000" }),
     );
   });
 
-  it('clears the time input after submission', async () => {
+  it("clears the time input after submission", async () => {
     render(<Form setConversion={vi.fn()} />);
 
     const input = screen.getByPlaceholderText(/date and time or a timestamp/i);
-    await userEvent.type(input, '1700000000');
-    await userEvent.click(screen.getByRole('button', { name: /convert/i }));
+    await userEvent.type(input, "1700000000");
+    await userEvent.click(screen.getByRole("button", { name: /convert/i }));
 
-    expect(input).toHaveValue('');
+    expect(input).toHaveValue("");
   });
 });

--- a/src/components/Converter/Form.tsx
+++ b/src/components/Converter/Form.tsx
@@ -4,14 +4,14 @@ import {
   useRef,
   useState,
   type FormEvent,
-} from 'react';
-import { SelectInstance } from 'react-select';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faClock } from '@fortawesome/sharp-duotone-light-svg-icons';
-import { IFormData, IValue } from '../../lib/types';
-import Section from '../Shared/Section';
-import Button from '../Shared/Button';
-import Select from './Select';
+} from "react";
+import { SelectInstance } from "react-select";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClock } from "@fortawesome/sharp-duotone-light-svg-icons";
+import { IFormData, IValue } from "../../lib/types";
+import Section from "../Shared/Section";
+import Button from "../Shared/Button";
+import Select from "./Select";
 
 interface IFormProps {
   setConversion: (data: IFormData) => void;
@@ -26,12 +26,12 @@ const Form = ({ setConversion }: IFormProps) => {
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       setConversion({
-        time: timeRef.current?.value || '',
-        timezone: (timezoneRef.current?.props.value as IValue)?.value || '',
+        time: timeRef.current?.value || "",
+        timezone: (timezoneRef.current?.props.value as IValue)?.value || "",
       });
 
       if (timeRef.current) {
-        timeRef.current.value = '';
+        timeRef.current.value = "";
         timeRef.current?.focus();
       }
     },
@@ -39,7 +39,7 @@ const Form = ({ setConversion }: IFormProps) => {
   );
 
   useEffect(() => {
-    import('../../data/timezones.json').then(({ default: options }) =>
+    import("../../data/timezones.json").then(({ default: options }) =>
       setOptions(options),
     );
   }, []);

--- a/src/components/Converter/Result.test.tsx
+++ b/src/components/Converter/Result.test.tsx
@@ -1,79 +1,79 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Result from './Result';
-import dayjs from '../../lib/dayjs';
-import { UTC } from '../../lib/constants';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Result from "./Result";
+import dayjs from "../../lib/dayjs";
+import { UTC } from "../../lib/constants";
 
 // 1700000000 = 2023-11-14 22:13:20 UTC
 const baseData = {
   dateTime: dayjs.unix(1700000000),
-  time: '1700000000',
+  time: "1700000000",
   timezone: UTC,
-  title: 'Converted time',
+  title: "Converted time",
 };
 
-describe('Result', () => {
-  it('renders the result title', () => {
+describe("Result", () => {
+  it("renders the result title", () => {
     render(<Result data={baseData} />);
-    expect(screen.getByText('Converted time')).toBeInTheDocument();
+    expect(screen.getByText("Converted time")).toBeInTheDocument();
   });
 
-  it('renders the unix timestamp', () => {
+  it("renders the unix timestamp", () => {
     render(<Result data={baseData} />);
-    expect(screen.getByText('1700000000')).toBeInTheDocument();
+    expect(screen.getByText("1700000000")).toBeInTheDocument();
   });
 
-  it('renders the UTC date', () => {
+  it("renders the UTC date", () => {
     const { container } = render(<Result data={baseData} />);
-    expect(container.querySelector('#results-utc')).toHaveTextContent(
-      '2023-11-14',
+    expect(container.querySelector("#results-utc")).toHaveTextContent(
+      "2023-11-14",
     );
   });
 
-  it('renders ISO 8601 format', () => {
+  it("renders ISO 8601 format", () => {
     render(<Result data={baseData} />);
     expect(screen.getByText(/2023-11-14T/)).toBeInTheDocument();
   });
 
-  it('renders an error alert when error is set', () => {
+  it("renders an error alert when error is set", () => {
     render(
       <Result
         data={{
           ...baseData,
-          error: 'Invalid time provided. Switched to current time.',
+          error: "Invalid time provided. Switched to current time.",
         }}
       />,
     );
     expect(screen.getByText(/Invalid time provided/)).toBeInTheDocument();
   });
 
-  it('renders a warning alert when warning is set', () => {
+  it("renders a warning alert when warning is set", () => {
     render(
       <Result
         data={{
           ...baseData,
-          warning: 'Invalid timezone provided. Switched to UTC.',
+          warning: "Invalid timezone provided. Switched to UTC.",
         }}
       />,
     );
     expect(screen.getByText(/Invalid timezone provided/)).toBeInTheDocument();
   });
 
-  it('shows the timezone row when timezone is not UTC', () => {
-    render(<Result data={{ ...baseData, timezone: 'America/New_York' }} />);
-    expect(screen.getByText('America/New_York')).toBeInTheDocument();
+  it("shows the timezone row when timezone is not UTC", () => {
+    render(<Result data={{ ...baseData, timezone: "America/New_York" }} />);
+    expect(screen.getByText("America/New_York")).toBeInTheDocument();
   });
 
-  it('does not show a timezone row for UTC', () => {
+  it("does not show a timezone row for UTC", () => {
     const { container } = render(<Result data={baseData} />);
     // the per-timezone dd only renders for non-UTC timezones
     expect(
-      container.querySelector('#results-timezone'),
+      container.querySelector("#results-timezone"),
     ).not.toBeInTheDocument();
   });
 
-  it('renders the Repeat link', () => {
+  it("renders the Repeat link", () => {
     render(<Result data={baseData} />);
-    expect(screen.getByRole('link', { name: /repeat/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /repeat/i })).toBeInTheDocument();
   });
 });

--- a/src/components/Converter/Result.tsx
+++ b/src/components/Converter/Result.tsx
@@ -1,23 +1,23 @@
-import { useCallback, useEffect } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useCallback, useEffect } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCircleInfo,
   faRedo,
   faCopy,
-} from '@fortawesome/sharp-duotone-light-svg-icons';
+} from "@fortawesome/sharp-duotone-light-svg-icons";
 import {
   DOCUMENT_TITLE,
   LONG_DATE,
   RFC_2822,
   SHORT_DATE,
   UTC,
-} from '../../lib/constants';
-import { IConversion } from '../../lib/types';
-import Alert from '../Shared/Alert';
-import Section from '../Shared/Section';
-import Button from '../Shared/Button';
-import useCopyToClipboard from '../../lib/hooks/useCopyToClipboard';
-import { getRequestUrl } from '../../lib/functions';
+} from "../../lib/constants";
+import { IConversion } from "../../lib/types";
+import Alert from "../Shared/Alert";
+import Section from "../Shared/Section";
+import Button from "../Shared/Button";
+import useCopyToClipboard from "../../lib/hooks/useCopyToClipboard";
+import { getRequestUrl } from "../../lib/functions";
 
 interface IResultProps {
   data: IConversion;
@@ -35,7 +35,7 @@ const Result = ({ data }: IResultProps) => {
   useEffect(() => {
     const documentTime =
       !timezone || timezone === UTC ? dateTime.utc() : dateTime.tz(timezone);
-    document.title = documentTime.format(LONG_DATE) + ' - ' + DOCUMENT_TITLE;
+    document.title = documentTime.format(LONG_DATE) + " - " + DOCUMENT_TITLE;
   }, [dateTime, timezone]);
 
   return (
@@ -46,7 +46,7 @@ const Result = ({ data }: IResultProps) => {
 
       <div className="card__body">
         {(error || warning) && (
-          <Alert type={error ? 'error' : 'warning'}>{error || warning}</Alert>
+          <Alert type={error ? "error" : "warning"}>{error || warning}</Alert>
         )}
         <dl id="results">
           <dt className="fw-bold">
@@ -91,7 +91,7 @@ const Result = ({ data }: IResultProps) => {
           )}
 
           <dt className="fw-bold mt-2">ISO 8601</dt>
-          <dd>{dateTime?.format('YYYY-MM-DDTHH:mm:ss.SSSZ')}</dd>
+          <dd>{dateTime?.format("YYYY-MM-DDTHH:mm:ss.SSSZ")}</dd>
           <dt className="fw-bold mt-2">RFC 2822</dt>
           <dd>{dateTime?.format(RFC_2822)}</dd>
         </dl>

--- a/src/components/Converter/Select.tsx
+++ b/src/components/Converter/Select.tsx
@@ -1,8 +1,8 @@
-import { useMemo, type Ref } from 'react';
-import ReactSelect, { SelectInstance, StylesConfig } from 'react-select';
-import { IValue } from '../../lib/types';
+import { useMemo, type Ref } from "react";
+import ReactSelect, { SelectInstance, StylesConfig } from "react-select";
+import { IValue } from "../../lib/types";
 
-type ISize = 'sm' | 'md' | 'lg';
+type ISize = "sm" | "md" | "lg";
 
 interface ISelectProps {
   id?: string;
@@ -18,31 +18,31 @@ const Select = ({ innerRef, size, ...props }: ISelectProps) => {
     () => ({
       container: (provided) => ({
         ...provided,
-        marginBottom: '0.25rem',
+        marginBottom: "0.25rem",
       }),
       control: (provided, state) => {
         const fontSize =
-          size === 'lg' ? '1.25rem' : size === 'sm' ? '0.875rem' : '1rem';
-        const borderRadius = size === 'lg' ? '0.25rem' : '0.125rem';
+          size === "lg" ? "1.25rem" : size === "sm" ? "0.875rem" : "1rem";
+        const borderRadius = size === "lg" ? "0.25rem" : "0.125rem";
 
         return {
           ...provided,
-          borderColor: 'var(--grey600)',
+          borderColor: "var(--grey600)",
           borderRadius,
           boxShadow: state.isFocused
-            ? '0 0 0 0.2rem var(--focusShadow)'
+            ? "0 0 0 0.2rem var(--focusShadow)"
             : provided.boxShadow,
-          '&:hover': {
-            borderColor: 'var(--grey600)',
+          "&:hover": {
+            borderColor: "var(--grey600)",
           },
-          color: 'var(--black)',
+          color: "var(--black)",
           fontSize,
-          padding: 'calc(0.25em + 1px) 0.5em',
+          padding: "calc(0.25em + 1px) 0.5em",
         };
       },
       placeholder: (provided) => ({
         ...provided,
-        color: 'rgb(117, 117, 117)', // Chrome default placeholder color
+        color: "rgb(117, 117, 117)", // Chrome default placeholder color
         marginLeft: 0,
         marginRight: 4, // default margin-block is 2px
       }),

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,28 +1,28 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import Header from './Header';
-import { DOCUMENT_TITLE } from '../../lib/constants';
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Header from "./Header";
+import { DOCUMENT_TITLE } from "../../lib/constants";
 
-describe('Header', () => {
-  it('renders the document title', () => {
+describe("Header", () => {
+  it("renders the document title", () => {
     render(<Header />);
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       DOCUMENT_TITLE,
     );
   });
 
-  it('renders a link to the home page', () => {
+  it("renders a link to the home page", () => {
     render(<Header />);
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', '/');
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/");
   });
 
-  it('renders the logo SVG', () => {
+  it("renders the logo SVG", () => {
     const { container } = render(<Header />);
-    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
   });
 
-  it('renders the brand name', () => {
+  it("renders the brand name", () => {
     render(<Header />);
     expect(screen.getByText(/craigmcn/i)).toBeInTheDocument();
   });

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
-import Logo from './Logo';
-import { DOCUMENT_TITLE } from '../../lib/constants';
+import Logo from "./Logo";
+import { DOCUMENT_TITLE } from "../../lib/constants";
 
 const Header = () => {
   return (

--- a/src/components/Shared/Alert.test.tsx
+++ b/src/components/Shared/Alert.test.tsx
@@ -1,26 +1,26 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Alert from './Alert';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Alert from "./Alert";
 
-describe('Alert', () => {
-  it('renders children', () => {
+describe("Alert", () => {
+  it("renders children", () => {
     render(<Alert>Something went wrong</Alert>);
-    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
   });
 
-  it('renders as an error alert by default', () => {
+  it("renders as an error alert by default", () => {
     const { container } = render(<Alert>Error message</Alert>);
-    expect(container.querySelector('.alert--danger')).toBeInTheDocument();
+    expect(container.querySelector(".alert--danger")).toBeInTheDocument();
   });
 
-  it('renders as a warning alert when type is warning', () => {
+  it("renders as a warning alert when type is warning", () => {
     const { container } = render(<Alert type="warning">Watch out</Alert>);
-    expect(container.querySelector('.alert--warning')).toBeInTheDocument();
-    expect(container.querySelector('.alert--danger')).not.toBeInTheDocument();
+    expect(container.querySelector(".alert--warning")).toBeInTheDocument();
+    expect(container.querySelector(".alert--danger")).not.toBeInTheDocument();
   });
 
-  it('includes the alert base class', () => {
+  it("includes the alert base class", () => {
     const { container } = render(<Alert>Test</Alert>);
-    expect(container.querySelector('.alert')).toBeInTheDocument();
+    expect(container.querySelector(".alert")).toBeInTheDocument();
   });
 });

--- a/src/components/Shared/Alert.tsx
+++ b/src/components/Shared/Alert.tsx
@@ -1,19 +1,19 @@
-import type { ReactNode } from 'react';
-import classNames from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { ReactNode } from "react";
+import classNames from "classnames";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCircleExclamation,
   faTriangleExclamation,
-} from '@fortawesome/sharp-duotone-light-svg-icons';
+} from "@fortawesome/sharp-duotone-light-svg-icons";
 
 interface IAlertProps {
   children: ReactNode;
-  type?: 'error' | 'warning';
+  type?: "error" | "warning";
 }
 
 const alertClass = {
-  error: 'alert--danger',
-  warning: 'alert--warning',
+  error: "alert--danger",
+  warning: "alert--warning",
 };
 
 const icon = {
@@ -21,9 +21,9 @@ const icon = {
   warning: faTriangleExclamation,
 };
 
-const Alert = ({ type = 'error', children }: IAlertProps) => {
+const Alert = ({ type = "error", children }: IAlertProps) => {
   return (
-    <div className={classNames('alert alert--sm mb-4', alertClass[type])}>
+    <div className={classNames("alert alert--sm mb-4", alertClass[type])}>
       <div className="alert__icon">
         <FontAwesomeIcon icon={icon[type]} size="sm" />
       </div>

--- a/src/components/Shared/Button.test.tsx
+++ b/src/components/Shared/Button.test.tsx
@@ -1,44 +1,44 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import Button from './Button';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button from "./Button";
 
-describe('Button', () => {
-  it('renders as a <button> by default', () => {
+describe("Button", () => {
+  it("renders as a <button> by default", () => {
     render(<Button>Click me</Button>);
     expect(
-      screen.getByRole('button', { name: 'Click me' }),
+      screen.getByRole("button", { name: "Click me" }),
     ).toBeInTheDocument();
   });
 
-  it('renders as an <a> when href is provided', () => {
+  it("renders as an <a> when href is provided", () => {
     render(<Button href="/somewhere">Go</Button>);
-    const link = screen.getByRole('link', { name: 'Go' });
+    const link = screen.getByRole("link", { name: "Go" });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/somewhere');
+    expect(link).toHaveAttribute("href", "/somewhere");
   });
 
-  it('calls onClick when the button is clicked', async () => {
+  it("calls onClick when the button is clicked", async () => {
     const onClick = vi.fn();
     render(<Button onClick={onClick}>Click me</Button>);
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole("button"));
     expect(onClick).toHaveBeenCalledOnce();
   });
 
-  it('applies the base button class plus any additional className', () => {
+  it("applies the base button class plus any additional className", () => {
     render(<Button className="button--primary">Test</Button>);
-    const btn = screen.getByRole('button');
-    expect(btn).toHaveClass('button');
-    expect(btn).toHaveClass('button--primary');
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveClass("button");
+    expect(btn).toHaveClass("button--primary");
   });
 
-  it('sets the button type attribute', () => {
+  it("sets the button type attribute", () => {
     render(<Button type="submit">Submit</Button>);
-    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
   });
 
-  it('sets the title attribute', () => {
+  it("sets the title attribute", () => {
     render(<Button title="My title">Test</Button>);
-    expect(screen.getByRole('button')).toHaveAttribute('title', 'My title');
+    expect(screen.getByRole("button")).toHaveAttribute("title", "My title");
   });
 });

--- a/src/components/Shared/Button.tsx
+++ b/src/components/Shared/Button.tsx
@@ -1,10 +1,10 @@
-import type { MouseEvent, ReactNode } from 'react';
-import classNames from 'classnames';
+import type { MouseEvent, ReactNode } from "react";
+import classNames from "classnames";
 
 interface IButtonProps {
   children: ReactNode;
   className?: string;
-  type?: 'button' | 'submit' | 'reset';
+  type?: "button" | "submit" | "reset";
   href?: string;
   title?: string;
   onClick?: (e?: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
@@ -13,7 +13,7 @@ interface IButtonProps {
 const Button = ({
   children,
   className,
-  type = 'button',
+  type = "button",
   href,
   title,
   ...props
@@ -22,7 +22,7 @@ const Button = ({
     <>
       {!href && (
         <button
-          className={classNames('button', className)}
+          className={classNames("button", className)}
           type={type}
           title={title}
           {...props}
@@ -32,7 +32,7 @@ const Button = ({
       )}
       {href && (
         <a
-          className={classNames('button', className)}
+          className={classNames("button", className)}
           href={href}
           title={title}
           {...props}

--- a/src/components/Shared/Main.tsx
+++ b/src/components/Shared/Main.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode } from "react";
 
 interface IMainProps {
   children: ReactNode;

--- a/src/components/Shared/Section.tsx
+++ b/src/components/Shared/Section.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import classNames from 'classnames';
+import type { ReactNode } from "react";
+import classNames from "classnames";
 
 interface ISectionProps {
   children: ReactNode;
@@ -9,7 +9,7 @@ interface ISectionProps {
 const Section = ({ children, className, ...props }: ISectionProps) => (
   <section
     className={classNames(
-      'flex__item flex__item--12 flex__item--6-md',
+      "flex__item flex__item--12 flex__item--6-md",
       className,
     )}
     {...props}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
-import { StrictMode } from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
-export const DOCUMENT_TITLE = 'Unix Timestamp Converter';
-export const UTC = 'UTC';
-export const NOW = 'now';
+export const DOCUMENT_TITLE = "Unix Timestamp Converter";
+export const UTC = "UTC";
+export const NOW = "now";
 // Date formats
-export const LONG_DATE = 'dddd, MMMM D YYYY h:mm:ss a z';
-export const SHORT_DATE = 'YYYY-MM-DD HH:mm:ss z';
-export const RFC_2822 = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
+export const LONG_DATE = "dddd, MMMM D YYYY h:mm:ss a z";
+export const SHORT_DATE = "YYYY-MM-DD HH:mm:ss z";
+export const RFC_2822 = "ddd, DD MMM YYYY HH:mm:ss ZZ";

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,7 +1,7 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import advancedFormat from "dayjs/plugin/advancedFormat";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);

--- a/src/lib/functions/convertTime.test.ts
+++ b/src/lib/functions/convertTime.test.ts
@@ -1,36 +1,36 @@
-import { describe, it, expect } from 'vitest';
-import { convertTime } from './convertTime';
-import { UTC } from '../constants';
+import { describe, it, expect } from "vitest";
+import { convertTime } from "./convertTime";
+import { UTC } from "../constants";
 
-describe('convertTime', () => {
-  describe('numeric inputs', () => {
-    it('converts a unix timestamp in seconds', () => {
+describe("convertTime", () => {
+  describe("numeric inputs", () => {
+    it("converts a unix timestamp in seconds", () => {
       const result = convertTime(1700000000);
       expect(result.dateTime.unix()).toBe(1700000000);
       expect(result.error).toBeUndefined();
-      expect(result.title).toBe('Converted time');
+      expect(result.title).toBe("Converted time");
     });
 
-    it('converts a string unix timestamp in seconds', () => {
-      const result = convertTime('1700000000');
+    it("converts a string unix timestamp in seconds", () => {
+      const result = convertTime("1700000000");
       expect(result.dateTime.unix()).toBe(1700000000);
     });
 
-    it('converts milliseconds (>= 1e10, < 1e13)', () => {
+    it("converts milliseconds (>= 1e10, < 1e13)", () => {
       const result = convertTime(1700000000000);
       expect(result.dateTime.unix()).toBe(1700000000);
     });
 
-    it('converts microseconds (>= 1e13, < 1e16)', () => {
+    it("converts microseconds (>= 1e13, < 1e16)", () => {
       const result = convertTime(1700000000000000);
       expect(result.dateTime.unix()).toBe(1700000000);
     });
   });
 
-  describe('natural language inputs', () => {
+  describe("natural language inputs", () => {
     it('parses "now" as the current time', () => {
       const before = Math.floor(Date.now() / 1000);
-      const result = convertTime('now');
+      const result = convertTime("now");
       const after = Math.ceil(Date.now() / 1000);
       expect(result.dateTime.unix()).toBeGreaterThanOrEqual(before);
       expect(result.dateTime.unix()).toBeLessThanOrEqual(after);
@@ -39,76 +39,76 @@ describe('convertTime', () => {
 
     it('parses "now()" as the current time', () => {
       const before = Math.floor(Date.now() / 1000);
-      const result = convertTime('now()');
+      const result = convertTime("now()");
       const after = Math.ceil(Date.now() / 1000);
       expect(result.dateTime.unix()).toBeGreaterThanOrEqual(before);
       expect(result.dateTime.unix()).toBeLessThanOrEqual(after);
     });
 
-    it('parses a natural language date string', () => {
-      const result = convertTime('January 1, 2024 00:00:00');
+    it("parses a natural language date string", () => {
+      const result = convertTime("January 1, 2024 00:00:00");
       expect(result.error).toBeUndefined();
       expect(result.dateTime.unix()).toBeGreaterThan(0);
     });
 
-    it('returns an error for an unparseable string', () => {
-      const result = convertTime('not a date xyz');
+    it("returns an error for an unparseable string", () => {
+      const result = convertTime("not a date xyz");
       expect(result.error).toBeTruthy();
     });
   });
 
-  describe('empty / falsy input', () => {
+  describe("empty / falsy input", () => {
     it("uses the current time and sets title to 'Current time'", () => {
       const before = Math.floor(Date.now() / 1000);
-      const result = convertTime('');
+      const result = convertTime("");
       const after = Math.ceil(Date.now() / 1000);
       expect(result.dateTime.unix()).toBeGreaterThanOrEqual(before);
       expect(result.dateTime.unix()).toBeLessThanOrEqual(after);
-      expect(result.title).toBe('Current time');
+      expect(result.title).toBe("Current time");
     });
   });
 
-  describe('timezone handling', () => {
-    it('defaults to UTC when no timezone is provided', () => {
+  describe("timezone handling", () => {
+    it("defaults to UTC when no timezone is provided", () => {
       const result = convertTime(1700000000);
       expect(result.timezone).toBe(UTC);
       expect(result.warning).toBeUndefined();
     });
 
-    it('accepts a valid IANA timezone', () => {
-      const result = convertTime(1700000000, 'America/New_York');
-      expect(result.timezone).toBe('America/New_York');
+    it("accepts a valid IANA timezone", () => {
+      const result = convertTime(1700000000, "America/New_York");
+      expect(result.timezone).toBe("America/New_York");
       expect(result.warning).toBeUndefined();
     });
 
-    it('warns and falls back to UTC for an invalid timezone', () => {
-      const result = convertTime(1700000000, 'Not/ATimezone');
+    it("warns and falls back to UTC for an invalid timezone", () => {
+      const result = convertTime(1700000000, "Not/ATimezone");
       expect(result.warning).toBeTruthy();
       expect(result.timezone).toBe(UTC);
     });
 
-    it('returns time and timezone on the result', () => {
-      const result = convertTime(1700000000, 'UTC');
+    it("returns time and timezone on the result", () => {
+      const result = convertTime(1700000000, "UTC");
       expect(result.time).toBe(1700000000);
       expect(result.timezone).toBe(UTC);
     });
   });
 
-  describe('output shape', () => {
-    it('returns a dateTime, time, timezone, and title', () => {
+  describe("output shape", () => {
+    it("returns a dateTime, time, timezone, and title", () => {
       const result = convertTime(1700000000);
       expect(result).toMatchObject({
         time: 1700000000,
         timezone: UTC,
-        title: 'Converted time',
+        title: "Converted time",
       });
       expect(result.dateTime).toBeDefined();
     });
 
-    it('returns a numeric timestamp as time when input is falsy', () => {
+    it("returns a numeric timestamp as time when input is falsy", () => {
       // empty input → falls back to Date.now() in milliseconds (truthy number, not NOW)
-      const result = convertTime('');
-      expect(typeof result.time).toBe('number');
+      const result = convertTime("");
+      expect(typeof result.time).toBe("number");
     });
   });
 });

--- a/src/lib/functions/convertTime.ts
+++ b/src/lib/functions/convertTime.ts
@@ -1,7 +1,7 @@
-import * as chrono from 'chrono-node';
-import dayjs from '../dayjs';
-import { IConversion } from '../types';
-import { NOW, UTC } from '../constants';
+import * as chrono from "chrono-node";
+import dayjs from "../dayjs";
+import { IConversion } from "../types";
+import { NOW, UTC } from "../constants";
 
 export const convertTime = (
   submitTime: number | string,
@@ -14,7 +14,7 @@ export const convertTime = (
   let chronoTime;
   let error;
   let warning;
-  let title = 'Converted time';
+  let title = "Converted time";
   let timezone = submitTimezone || UTC;
 
   if (submitTime) {
@@ -23,14 +23,14 @@ export const convertTime = (
   } else {
     const d = new Date();
     numericTime = time = d.getTime();
-    title = 'Current time';
+    title = "Current time";
   }
 
   if (
     !timezone ||
-    (!Intl.supportedValuesOf('timeZone').includes(timezone) && timezone !== UTC)
+    (!Intl.supportedValuesOf("timeZone").includes(timezone) && timezone !== UTC)
   ) {
-    warning = timezone ? 'Invalid timezone provided. Switched to UTC.' : '';
+    warning = timezone ? "Invalid timezone provided. Switched to UTC." : "";
     timezone = UTC;
   }
 
@@ -46,13 +46,13 @@ export const convertTime = (
       dateTime = dayjs(chronoTime[0].start.date());
       if (timezone && timezone !== UTC) {
         const dateUtc = Date.UTC(
-          chronoTime[0].start.get('year') || defaultDate.getFullYear(),
+          chronoTime[0].start.get("year") || defaultDate.getFullYear(),
           // @ts-expect-error: Object is possibly 'null'.
-          chronoTime[0].start.get('month') - 1 || defaultDate.getMonth(),
-          chronoTime[0].start.get('day') || 1,
-          chronoTime[0].start.get('hour') || 0,
-          chronoTime[0].start.get('minute') || 0,
-          chronoTime[0].start.get('second') || 0,
+          chronoTime[0].start.get("month") - 1 || defaultDate.getMonth(),
+          chronoTime[0].start.get("day") || 1,
+          chronoTime[0].start.get("hour") || 0,
+          chronoTime[0].start.get("minute") || 0,
+          chronoTime[0].start.get("second") || 0,
         );
         // utcOffset() returns minutes east of UTC; moment-timezone's parse()
         // returned minutes west, so negate before applying to the unix calc.
@@ -62,7 +62,7 @@ export const convertTime = (
         );
       }
     } else {
-      error = 'Invalid time provided. Switched to current time.';
+      error = "Invalid time provided. Switched to current time.";
       dateTime = dayjs().tz(timezone || UTC);
     }
   } else {

--- a/src/lib/functions/index.test.ts
+++ b/src/lib/functions/index.test.ts
@@ -1,49 +1,49 @@
-import { describe, it, expect } from 'vitest';
-import { getRequestUrl } from '.';
-import dayjs from '../dayjs';
-import { NOW } from '../constants';
+import { describe, it, expect } from "vitest";
+import { getRequestUrl } from ".";
+import dayjs from "../dayjs";
+import { NOW } from "../constants";
 
 // jsdom is configured with url: 'http://localhost/' in vitest.config.ts
 
 const dateTime = dayjs.unix(1700000000);
 
-describe('getRequestUrl', () => {
-  it('returns a URL with time and timezone query params', () => {
+describe("getRequestUrl", () => {
+  it("returns a URL with time and timezone query params", () => {
     const url = getRequestUrl({
-      time: '1700000000',
-      timezone: 'UTC',
+      time: "1700000000",
+      timezone: "UTC",
       dateTime,
     });
-    expect(url).toContain('time=1700000000');
-    expect(url).toContain('timezone=UTC');
+    expect(url).toContain("time=1700000000");
+    expect(url).toContain("timezone=UTC");
   });
 
-  it('uses the unix timestamp from dateTime as the time param', () => {
+  it("uses the unix timestamp from dateTime as the time param", () => {
     const url = getRequestUrl({
-      time: 'anything',
-      timezone: 'UTC',
+      time: "anything",
+      timezone: "UTC",
       dateTime,
     });
     expect(url).toContain(`time=${dateTime.unix()}`);
   });
 
   it(`uses "${NOW}" when time is the NOW constant`, () => {
-    const url = getRequestUrl({ time: NOW, timezone: 'UTC', dateTime });
+    const url = getRequestUrl({ time: NOW, timezone: "UTC", dateTime });
     expect(url).toContain(`time=${NOW}`);
-    expect(url).not.toContain('time=1700000000');
+    expect(url).not.toContain("time=1700000000");
   });
 
-  it('includes the current origin and pathname', () => {
+  it("includes the current origin and pathname", () => {
     const url = getRequestUrl({
-      time: '1700000000',
-      timezone: 'UTC',
+      time: "1700000000",
+      timezone: "UTC",
       dateTime,
     });
     expect(url).toMatch(/^http:\/\/localhost\//);
   });
 
-  it('omits timezone from params when empty', () => {
-    const url = getRequestUrl({ time: '1700000000', timezone: '', dateTime });
-    expect(url).toContain('timezone=');
+  it("omits timezone from params when empty", () => {
+    const url = getRequestUrl({ time: "1700000000", timezone: "", dateTime });
+    expect(url).toContain("timezone=");
   });
 });

--- a/src/lib/functions/index.ts
+++ b/src/lib/functions/index.ts
@@ -1,5 +1,5 @@
-import { NOW } from '../constants';
-import { IConversion } from '../types';
+import { NOW } from "../constants";
+import { IConversion } from "../types";
 
 export const getRequestUrl = ({
   time,
@@ -13,7 +13,7 @@ export const getRequestUrl = ({
       (time as string).toLowerCase() === NOW || !dateTime
         ? NOW
         : dateTime.unix().toString(),
-    timezone: timezone || '',
+    timezone: timezone || "",
   };
   const new_params = new URLSearchParams(Object.entries(add_params)).toString();
 

--- a/src/lib/hooks/useConversion.test.ts
+++ b/src/lib/hooks/useConversion.test.ts
@@ -1,52 +1,52 @@
-import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import useConversion from './useConversion';
-import { UTC, NOW } from '../constants';
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import useConversion from "./useConversion";
+import { UTC, NOW } from "../constants";
 
-describe('useConversion', () => {
-  it('returns initial data with NOW and UTC defaults', () => {
+describe("useConversion", () => {
+  it("returns initial data with NOW and UTC defaults", () => {
     const { result } = renderHook(() => useConversion());
     expect(result.current.data.time).toBe(NOW);
     expect(result.current.data.timezone).toBe(UTC);
   });
 
-  it('exposes a setConversion function', () => {
+  it("exposes a setConversion function", () => {
     const { result } = renderHook(() => useConversion());
-    expect(typeof result.current.setConversion).toBe('function');
+    expect(typeof result.current.setConversion).toBe("function");
   });
 
-  it('updates data when setConversion is called', async () => {
+  it("updates data when setConversion is called", async () => {
     const { result } = renderHook(() => useConversion());
 
     await act(() => {
-      result.current.setConversion({ time: '1700000000', timezone: UTC });
+      result.current.setConversion({ time: "1700000000", timezone: UTC });
     });
 
-    expect(result.current.data.time).toBe('1700000000');
+    expect(result.current.data.time).toBe("1700000000");
   });
 
-  it('sets an error for an invalid time string', () => {
+  it("sets an error for an invalid time string", () => {
     const { result } = renderHook(() => useConversion());
 
     act(() => {
-      result.current.setConversion({ time: 'not-a-date', timezone: UTC });
+      result.current.setConversion({ time: "not-a-date", timezone: UTC });
     });
 
     expect(result.current.data.error).toBeTruthy();
   });
 
-  it('reads ?time= and ?timezone= query params as initial values', () => {
+  it("reads ?time= and ?timezone= query params as initial values", () => {
     window.history.replaceState(
       {},
-      '',
-      '/?time=1700000000&timezone=America%2FNew_York',
+      "",
+      "/?time=1700000000&timezone=America%2FNew_York",
     );
 
     const { result } = renderHook(() => useConversion());
 
-    expect(result.current.data.time).toBe('1700000000');
-    expect(result.current.data.timezone).toBe('America/New_York');
+    expect(result.current.data.time).toBe("1700000000");
+    expect(result.current.data.timezone).toBe("America/New_York");
 
-    window.history.replaceState({}, '', '/');
+    window.history.replaceState({}, "", "/");
   });
 });

--- a/src/lib/hooks/useConversion.ts
+++ b/src/lib/hooks/useConversion.ts
@@ -1,22 +1,22 @@
-import { useEffect, useState } from 'react';
-import { IConversion, IFormData } from '../types';
-import { convertTime } from '../functions/convertTime';
-import { UTC, NOW } from '../constants';
-import dayjs from '../dayjs';
+import { useEffect, useState } from "react";
+import { IConversion, IFormData } from "../types";
+import { convertTime } from "../functions/convertTime";
+import { UTC, NOW } from "../constants";
+import dayjs from "../dayjs";
 
 const useConversion = () => {
   const [conversion, setConversion] = useState<IFormData>(() => {
     const params = new URLSearchParams(window.location.search);
     return {
-      time: params.get('time') || NOW,
-      timezone: params.get('timezone') || UTC,
+      time: params.get("time") || NOW,
+      timezone: params.get("timezone") || UTC,
     };
   });
   const [data, setData] = useState<IConversion>({
     time: NOW,
     timezone: UTC,
     dateTime: dayjs(),
-    title: '',
+    title: "",
   });
 
   useEffect(() => {

--- a/src/lib/hooks/useCopyToClipboard.test.ts
+++ b/src/lib/hooks/useCopyToClipboard.test.ts
@@ -1,20 +1,20 @@
-import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import useCopyToClipboard from './useCopyToClipboard';
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useCopyToClipboard from "./useCopyToClipboard";
 
-describe('useCopyToClipboard', () => {
+describe("useCopyToClipboard", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('returns null as initial copied value', () => {
+  it("returns null as initial copied value", () => {
     const { result } = renderHook(() => useCopyToClipboard());
     expect(result.current[0]).toBeNull();
   });
 
-  it('copies text and returns true when clipboard is available', async () => {
+  it("copies text and returns true when clipboard is available", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, 'clipboard', {
+    Object.defineProperty(navigator, "clipboard", {
       value: { writeText },
       writable: true,
       configurable: true,
@@ -24,16 +24,16 @@ describe('useCopyToClipboard', () => {
 
     let success: boolean;
     await act(async () => {
-      success = await result.current[1]('hello');
+      success = await result.current[1]("hello");
     });
 
     expect(success!).toBe(true);
-    expect(result.current[0]).toBe('hello');
-    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(result.current[0]).toBe("hello");
+    expect(writeText).toHaveBeenCalledWith("hello");
   });
 
-  it('returns false and does not update state when clipboard is unavailable', async () => {
-    Object.defineProperty(navigator, 'clipboard', {
+  it("returns false and does not update state when clipboard is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
       value: undefined,
       writable: true,
       configurable: true,
@@ -43,16 +43,16 @@ describe('useCopyToClipboard', () => {
 
     let success: boolean;
     await act(async () => {
-      success = await result.current[1]('hello');
+      success = await result.current[1]("hello");
     });
 
     expect(success!).toBe(false);
     expect(result.current[0]).toBeNull();
   });
 
-  it('returns false and resets state when clipboard.writeText throws', async () => {
-    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
-    Object.defineProperty(navigator, 'clipboard', {
+  it("returns false and resets state when clipboard.writeText throws", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.defineProperty(navigator, "clipboard", {
       value: { writeText },
       writable: true,
       configurable: true,
@@ -62,7 +62,7 @@ describe('useCopyToClipboard', () => {
 
     let success: boolean;
     await act(async () => {
-      success = await result.current[1]('hello');
+      success = await result.current[1]("hello");
     });
 
     expect(success!).toBe(false);

--- a/src/lib/hooks/useCopyToClipboard.ts
+++ b/src/lib/hooks/useCopyToClipboard.ts
@@ -1,5 +1,5 @@
 // From https://usehooks-ts.com/react-hook/use-copy-to-clipboard
-import { useState } from 'react';
+import { useState } from "react";
 
 type CopiedValue = string | null;
 type CopyFn = (text: string) => Promise<boolean>; // Return success
@@ -9,7 +9,7 @@ function useCopyToClipboard(): [CopiedValue, CopyFn] {
 
   const copy: CopyFn = async (text) => {
     if (!navigator?.clipboard) {
-      console.warn('Clipboard not supported'); // eslint-disable-line no-console
+      console.warn("Clipboard not supported"); // eslint-disable-line no-console
       return false;
     }
 
@@ -19,7 +19,7 @@ function useCopyToClipboard(): [CopiedValue, CopyFn] {
       setCopiedText(text);
       return true;
     } catch (error) {
-      console.warn('Copy failed', error); // eslint-disable-line no-console
+      console.warn("Copy failed", error); // eslint-disable-line no-console
       setCopiedText(null);
       return false;
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,7 +8,7 @@ export interface IValue {
   label: string;
 }
 
-import type { Dayjs } from 'dayjs';
+import type { Dayjs } from "dayjs";
 
 export interface IConversion {
   dateTime: Dayjs;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,5 @@
-import '@testing-library/jest-dom/vitest';
-import { afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
 
 afterEach(cleanup);


### PR DESCRIPTION
## Summary

- Removes custom Prettier config (semi, singleQuote, tabWidth) in favour of Prettier defaults (`{}`) to align with the cross-repo standard
- Adds `[*.md]` section to `.editorconfig` (`trim_trailing_whitespace = false`)
- Reformats all 30 affected source files under the new defaults

No logic changes — formatting only.

## Test plan

- [x] `yarn format:check` passes
- [x] `yarn lint` passes
- [x] `tsc -b` passes
- [x] All 57 tests pass (`yarn test:run`)
- [x] Pre-commit hook ran cleanly on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)