### PR TITLE
docs: add format:check to README development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Converts a Unix timestamp or natural-language date string into UTC, local timezo
 yarn install
 yarn dev        # dev server at http://localhost:3120
 yarn build      # type-check + build to dist/
-yarn lint       # ESLint with auto-fix
-yarn format     # Prettier
-yarn coverage   # Vitest + coverage report
+yarn lint           # ESLint with auto-fix
+yarn format         # Prettier write
+yarn format:check   # Prettier check (used in pre-commit hook and CI)
+yarn coverage       # Vitest + coverage report
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary

Documents the `format:check` script (added in PR #49) in the README development commands block. Also clarifies `format` as "Prettier write" to distinguish the two.

## Test plan

- [x] README renders correctly — one new line added, no broken formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)