### PR TITLE
docs: add test:run to README development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ yarn build      # type-check + build to dist/
 yarn lint           # ESLint with auto-fix
 yarn format         # Prettier write
 yarn format:check   # Prettier check (used in pre-commit hook and CI)
-yarn coverage       # Vitest + coverage report
+yarn test:run       # Vitest single pass
+yarn coverage       # Vitest single pass with coverage report
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ yarn build      # type-check + build to dist/
 yarn lint           # ESLint with auto-fix
 yarn format         # Prettier write
 yarn format:check   # Prettier check (used in pre-commit hook and CI)
+yarn test           # Vitest watch mode
 yarn test:run       # Vitest single pass
 yarn coverage       # Vitest single pass with coverage report
 ```


### PR DESCRIPTION
## Summary

Addresses the gap flagged in the PR #51 review: `yarn test` and `yarn test:run` were listed in the Testing section but missing from the Development commands block. Also sharpens the `coverage` description to distinguish it from `test:run`.

## Test plan

- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)