### PR TITLE
chore: remove Yarn auto-injected security settings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,8 +1,3 @@
-approvedGitRepositories:
-  - "**"
-
-enableScripts: true
-
 nodeLinker: node-modules
 
 npmScopes:


### PR DESCRIPTION
## Summary

Remove `enableScripts: true` and `approvedGitRepositories: ["**"]` from `.yarnrc.yml`. Both were auto-injected by Yarn during the 4.9.1 → 4.14.1 upgrade for backward compatibility. Neither is needed in this repo — there are no lifecycle scripts and no git-sourced dependencies. Both settings unnecessarily widen the supply-chain attack surface.

## Test plan

- [ ] `yarn install` completes without errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)